### PR TITLE
Replaced PyTorch3D Library with NVIDIA Kaolin Library for supporting CUDA 12.4

### DIFF
--- a/PointCloudAE.ipynb
+++ b/PointCloudAE.ipynb
@@ -77,18 +77,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pytorch3d.loss import chamfer_distance # chamfer distance for calculating point cloud distance\n",
+    "from kaolin.metrics.pointcloud import chamfer_distance # chamfer distance for calculating point cloud distance\n",
     "\n",
     "optimizer = optim.Adam(net.parameters(), lr=0.0005)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +99,7 @@
     "        \n",
     "        data = data.to(device)\n",
     "        output = net(data.permute(0,2,1)) # transpose data for NumberxChannelxSize format\n",
-    "        loss, _ = chamfer_distance(data, output) \n",
+    "        loss = chamfer_distance(data, output).mean()\n",
     "        loss.backward()\n",
     "        optimizer.step()\n",
     "        \n",
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +118,7 @@
     "    with torch.no_grad():\n",
     "        data = data.to(device)\n",
     "        output = net(data.permute(0,2,1))\n",
-    "        loss, _ = chamfer_distance(data, output)\n",
+    "        loss = chamfer_distance(data, output).mean()\n",
     "        \n",
     "    return loss.item(), output.cpu()"
    ]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Dataset is sampled from ["A Scalable Active Framework for Region Annotation in 3
 ## Environment
 ```
 Tested with:
-PyTorch v1.5.0  
-PyTorch3D v0.2  
-Nvidia RTX2070 with CUDA 10.2
+PyTorch v2.5.1 
+kaolin v0.17.0 v0.2  
+Nvidia RTX4070 with CUDA 12.4
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Dataset is sampled from ["A Scalable Active Framework for Region Annotation in 3
 ```
 Tested with:
 PyTorch v2.5.1 
-kaolin v0.17.0 v0.2  
+Nvidia Kaolin v0.17.0
 Nvidia RTX4070 with CUDA 12.4
 ```


### PR DESCRIPTION
PyTorch3D Library does not have any installation wheel for CUDA 12+. Therefore, NVIDIA kaolin is used to compute the chamfer_distance. This change make this repository executable in CUDA 12+